### PR TITLE
 Add MvpDelegate reset method to clear existing presenters

### DIFF
--- a/mvp-state-lib/src/main/java/com/github/mvpstatelib/framework/MvpDelegate.java
+++ b/mvp-state-lib/src/main/java/com/github/mvpstatelib/framework/MvpDelegate.java
@@ -42,4 +42,8 @@ public class MvpDelegate {
         }
         presenterMap.remove(tag);
     }
+    
+    public static void resetPresenters() {
+        presenterMap.clear();
+    }
 }


### PR DESCRIPTION
Currently view tests receive existing instance of presenter instead of creating a new one. It is not always convenient since presenter's state could be changed before a new test begins